### PR TITLE
Combinatorial Fuzzing -- Fuzz with multiple mutations simultaneously …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,12 @@ Upcoming
 Features
 ^^^^^^^^
 - Fuzzing CLI -- Use main_helper() to use boofuzz's generic fuzzing CLI with your script.
+- Combinatorial fuzzing -- now fuzzes multiple mutations at once by default.
+- Added `Simple` primitive that uses only the specified values for fuzzing.
+- Fixed two memory leaks in the fuzz logger.
+- Test cases can now be specified and re-run by name.
 - Implemented visual request-graph rendering functions for Session
+- Added to web UIL: runtime, exec speed, current test case name.
 
 v0.3.0
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -50,6 +50,7 @@ from .primitives import (
     Mirror,
     QWord,
     RandomData,
+    Simple,
     Static,
     String,
     Word,
@@ -158,6 +159,7 @@ __all__ = [
     "s_size",
     "s_sizer",
     "s_static",
+    "s_simple",
     "s_string",
     "s_switch",
     "s_unknown",
@@ -170,6 +172,7 @@ __all__ = [
     "SizerNotUtilizedError",
     "SocketConnection",
     "SSLSocketConnection",
+    "Simple",
     "Static",
     "String",
     "SullyRuntimeError",
@@ -693,6 +696,25 @@ def s_static(value=None, name=None):
     """
 
     blocks.CURRENT.push(Static(name=name, default_value=value))
+
+
+def s_simple(value=None, name=None, fuzz_values=None, fuzzable=True):
+    """
+    Push a "Simple" primitive onto the current block stack. The only mutations will be those specified  in fuzz_values.
+
+    :see: Aliases: s_dunno(), s_raw(), s_unknown()
+
+    :type  value: Raw
+    :param value: Raw static data
+    :type  name:  str
+    :param name:  (Optional, def=None) Specifying a name gives you direct access to a primitive
+    :type  fuzz_values:  list
+    :param fuzz_values:  (Optional, def=None) List of fuzz values.
+    :type  fuzzable: bool
+    :param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
+    """
+
+    blocks.CURRENT.push(Simple(name=name, default_value=value, fuzz_values=fuzz_values, fuzzable=fuzzable))
 
 
 def s_mirror(primitive_name=None, name=None):

--- a/boofuzz/blocks/block.py
+++ b/boofuzz/blocks/block.py
@@ -62,20 +62,18 @@ class Block(FuzzableBlock):
         self._fuzz_complete = False  # whether or not we are done fuzzing this block.
         self._mutant_index = 0  # current mutation index.
 
-    def mutations(self, default_value):
+    def mutations(self, default_value, skip_elements=None):
         for item in self.stack:
             self.request.mutant = item
-            for mutation in item.get_mutations():
-                yield mutation
+            for mutations in item.get_mutations():
+                yield mutations
         if self.group is not None:
-            g = self.request.resolve_name(self.context_path, self.group)
-            m = list(g.get_mutations())
-            for group_mutation in m:
+            group = self.request.resolve_name(self.context_path, self.group)
+            for group_mutations in group.get_mutations():
                 for item in self.stack:
                     self.request.mutant = item
-                    for mutation in item.get_mutations():
-                        mutation.mutations[g.qualified_name] = group_mutation.mutations[g.qualified_name]
-                        yield mutation
+                    for mutations in item.get_mutations():
+                        yield group_mutations + mutations
 
     def num_mutations(self, default_value=None):
         n = super(Block, self).num_mutations(default_value=default_value)

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -202,8 +202,9 @@ class Request(FuzzableBlock, Node):
         else:
             raise BoofuzzNameResolutionError(ERR_NAME_NOT_FOUND.format(resolved_name))
 
-    def get_mutations(self, default_value=None):
-        return self.mutations(default_value=default_value)
+    def get_mutations(self, default_value=None, skip_elements=None):
+        return self.mutations(default_value=default_value, skip_elements=skip_elements)
+
 
     def get_num_mutations(self):
         return self.num_mutations()

--- a/boofuzz/fuzzable_block.py
+++ b/boofuzz/fuzzable_block.py
@@ -35,8 +35,12 @@ class FuzzableBlock(Fuzzable):
         else:
             self.stack = list(children)
 
-    def mutations(self, default_value):
+    def mutations(self, default_value, skip_elements=None):
+        if skip_elements is None:
+            skip_elements = []
         for item in self.stack:
+            if item.qualified_name in skip_elements:
+                continue
             self.request.mutant = item
             for mutation in item.get_mutations():
                 yield mutation

--- a/boofuzz/mutation.py
+++ b/boofuzz/mutation.py
@@ -3,5 +3,6 @@ import attr
 
 @attr.s
 class Mutation(object):
-    mutations = attr.ib(factory=dict)
-    message_path = attr.ib(factory=list)
+    value = attr.ib(type=bytes)
+    qualified_name = attr.ib(type=str)
+    index = attr.ib(type=int)

--- a/boofuzz/mutation_context.py
+++ b/boofuzz/mutation_context.py
@@ -1,7 +1,17 @@
 import attr
+import collections
 
 from .mutation import Mutation
 from .protocol_session import ProtocolSession
+
+
+def mutations_list_to_dict(mutations_list_or_dict):
+    if isinstance(mutations_list_or_dict, dict):
+        return mutations_list_or_dict
+    elif isinstance(mutations_list_or_dict, collections.Iterable):
+        return {mutation.qualified_name: mutation for mutation in mutations_list_or_dict}
+    else:
+        raise ValueError("Cannot initialize a MutationContext with mutations {0}".format(mutations_list_or_dict))
 
 
 @attr.s
@@ -18,5 +28,6 @@ class MutationContext(object):
     ProtocolSession does not necessarily have a MutationContext.
     """
 
-    mutation = attr.ib(type=Mutation)
+    mutations = attr.ib(factory=dict, converter=mutations_list_to_dict)  # maps qualified names to a Mutation
+    message_path = attr.ib(factory=list)
     protocol_session = attr.ib(type=ProtocolSession, default=None)

--- a/boofuzz/primitives/__init__.py
+++ b/boofuzz/primitives/__init__.py
@@ -10,6 +10,7 @@ from .group import Group
 from .mirror import Mirror
 from .qword import QWord
 from .random_data import RandomData
+from .simple import Simple
 from .static import Static
 from .string import String
 from .word import Word
@@ -26,6 +27,7 @@ __all__ = [
     "Mirror",
     "QWord",
     "RandomData",
+    "Simple",
     "Static",
     "String",
     "Word",

--- a/boofuzz/primitives/mirror.py
+++ b/boofuzz/primitives/mirror.py
@@ -61,7 +61,7 @@ class Mirror(BasePrimitive):
     def _render_primitive(self, primitive_name):
         return (
             self._request.resolve_name(self.context_path, primitive_name).render(
-                mutation_context=MutationContext(Mutation())
+                mutation_context=MutationContext()
             )
             if primitive_name is not None
             else None

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -5,7 +5,6 @@ from past.builtins import xrange
 
 from boofuzz import helpers
 from ..fuzzable import Fuzzable
-from ..mutation import Mutation
 
 
 class RandomData(Fuzzable):
@@ -66,7 +65,7 @@ class RandomData(Fuzzable):
             value = b""
             for _ in xrange(length):
                 value += struct.pack("B", random.randint(0, 255))
-            yield Mutation(mutations={self.qualified_name: value})
+            yield value
 
     def encode(self, value, mutation_context):
         return value

--- a/boofuzz/primitives/simple.py
+++ b/boofuzz/primitives/simple.py
@@ -1,0 +1,19 @@
+from ..fuzzable import Fuzzable
+
+
+class Simple(Fuzzable):
+    """Simple bytes value with manually specified fuzz values only.
+
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type default_value: Raw, optional
+    :param default_value: Raw static data
+    :type fuzz_values: list, optional
+    :param fuzz_values: List of fuzz values, defaults to None. If empty, Simple is equivalent to Static.
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    """
+
+    def __init__(self, name=None, default_value=None, fuzz_values=None, *args, **kwargs):
+        super(Simple, self).__init__(name=name, default_value=default_value, fuzz_values=fuzz_values, *args, **kwargs)

--- a/boofuzz/primitives/static.py
+++ b/boofuzz/primitives/static.py
@@ -3,7 +3,7 @@ from ..fuzzable import Fuzzable
 
 
 class Static(Fuzzable):
-    """Push a static value onto the current block stack.
+    """Static primitives are fixed and not mutated while fuzzing.
 
     :type name: str, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,

--- a/boofuzz/web/app.py
+++ b/boofuzz/web/app.py
@@ -74,7 +74,10 @@ def index_update():
             if app.session.fuzz_node is not None
             else None,
             "current_element": app.session.fuzz_node.name if app.session.fuzz_node is not None else None,
+            "current_test_case_name": app.session.current_test_case_name,
             "crashes": _crash_summary_info(),
+            "runtime": app.session.runtime,
+            "exec_speed": app.session.exec_speed,
         }
     }
 
@@ -97,7 +100,7 @@ def index():
         num_mutations = float(app.session.fuzz_node.get_num_mutations())
 
         try:
-            progress_current = mutant_index / num_mutations
+            progress_current = min(mutant_index / num_mutations, 1)
         except ZeroDivisionError:
             progress_current = 0
         num_bars = int(progress_current * 50)
@@ -115,7 +118,7 @@ def index():
         progress_total = 0
     else:
         try:
-            progress_total = total_mutant_index / total_num_mutations
+            progress_total = min(total_mutant_index / total_num_mutations, 1)
         except ZeroDivisionError:
             progress_total = 0
 
@@ -133,7 +136,7 @@ def index():
         "progress_total": progress_total,
         "progress_total_bar": progress_total_bar,
         "total_mutant_index": commify(int(total_mutant_index)),
-        "total_num_mutations": commify(int(total_num_mutations)) if total_num_mutations is not None else "N/A",
+        "total_num_mutations": commify(int(total_num_mutations)) if total_num_mutations is not None else None,
     }
 
     return render_template("index.html", state=state, crashes=crashes)

--- a/boofuzz/web/static/js/index.js
+++ b/boofuzz/web/static/js/index.js
@@ -11,16 +11,25 @@ const StringUtilities = {
 };
 
 function update_current_run_info(response) {
-    document.getElementById('current_index').textContent = response.session_info.current_index;
-    document.getElementById('num_mutations').textContent = response.session_info.num_mutations;
-    document.getElementById('current_index_element').textContent = response.session_info.current_index_element;
-    document.getElementById('num_mutations_element').textContent = response.session_info.num_mutations_element;
-    document.getElementById('current_element').textContent = response.session_info.current_element;
+    document.getElementById('current_index').textContent = response.session_info.current_index.toLocaleString();
+    document.getElementById('num_mutations').textContent = (response.session_info.num_mutations || "many").toLocaleString();
+    document.getElementById('current_index_element').textContent = response.session_info.current_index_element.toLocaleString();
+    document.getElementById('num_mutations_element').textContent = response.session_info.num_mutations_element.toLocaleString();
+    document.getElementById('current_element').textContent = response.session_info.current_element + ":";
+    document.getElementById('current_test_case_name').textContent = response.session_info.current_test_case_name;
+    document.getElementById('exec_speed').textContent = response.session_info.exec_speed.toFixed(1) + "/sec";
+    document.getElementById('run_time').textContent = response.session_info.runtime.toFixed(0) + " sec";
 
 
-    let fraction_complete_total = response.session_info.current_index / response.session_info.num_mutations;
-    document.getElementById('progress_percentage_total').textContent = progress_percentage(fraction_complete_total);
-    document.getElementById('progress_bar_total').textContent = progress_bars(fraction_complete_total);
+    if (response.session_info.num_mutations != null) {
+        let fraction_complete_total = response.session_info.current_index / response.session_info.num_mutations;
+        document.getElementById('progress_percentage_total').textContent = progress_percentage(fraction_complete_total);
+        document.getElementById('progress_bar_total').textContent = progress_bars(fraction_complete_total);
+    }
+    else {
+        document.getElementById('progress_percentage_total').textContent = "";
+        document.getElementById('progress_bar_total').textContent = "";
+    }
 
     let fraction_complete_element = response.session_info.current_index_element / response.session_info.num_mutations_element;
     document.getElementById('progress_percentage_element').textContent = progress_percentage(fraction_complete_element);
@@ -164,8 +173,8 @@ function continually_update_current_test_case_log()
 
 function progress_bars(fraction){
     return '[' +
-        StringUtilities.repeat('=', Math.round(fraction * 50)) +
-        StringUtilities.repeat(nbsp, 50 - Math.round(fraction * 50)) + ']';
+        StringUtilities.repeat('=', Math.round(Math.min(fraction, 1) * 50)) +
+        StringUtilities.repeat(nbsp, 50 - Math.round(Math.min(fraction, 1) * 50)) + ']';
 }
 
 function progress_percentage(fraction){

--- a/boofuzz/web/templates/index.html
+++ b/boofuzz/web/templates/index.html
@@ -20,9 +20,15 @@
                     <td class="summary-content-row-header-text">Total:</td>
                     <td id="current_index"> {{ state.total_mutant_index }} </td>
                     <td> of </td>
-                    <td id="num_mutations"> {{ state.total_num_mutations }} </td>
-                    <td class="fixed" id="progress_bar_total"> {{ state.progress_total_bar | safe }} </td>
-                    <td id="progress_percentage_total"> {{ state.progress_total }} </td>
+                    {% if state.total_num_mutations is not none %}
+                        <td id="num_mutations"> {{ state.total_num_mutations }} </td>
+                        <td class="fixed" id="progress_bar_total"> {{ state.progress_total_bar | safe }} </td>
+                        <td id="progress_percentage_total"> {{ state.progress_total }} </td>
+                    {% else %}
+                        <td id="num_mutations">many</td>
+                        <td class="fixed" id="progress_bar_total"> </td>
+                        <td id="progress_percentage_total"> </td>
+                    {% endif %}
                 </tr>
                 <tr>
                     <td id="current_element" class="summary-content-row-header-text"> {{ state.current_name }}: </td>
@@ -31,6 +37,18 @@
                     <td id="num_mutations_element"> {{ state.current_num_mutations }} </td>
                     <td id="progress_bar_element" class="fixed"> {{ state.progress_current_bar | safe }} </td>
                     <td id="progress_percentage_element"> {{ state.progress_current }} </td>
+                </tr>
+                <tr>
+                    <td class="summary-content-row-header-text">run time</td>
+                    <td id="run_time"> {{ state.session.runtime | round | int }} sec</td>
+                </tr>
+                <tr>
+                    <td class="summary-content-row-header-text">exec speed</td>
+                    <td id="exec_speed"> {{ state.session.exec_speed | round(1) }}/sec</td>
+                </tr>
+                <tr>
+                    <td class="summary-content-row-header-text">current</td>
+                    <td id="current_test_case_name" colspan="5"> {{ state.session.current_test_case_name }} </td>
                 </tr>
             </table> </td> </tr>
             <tr> <td>

--- a/docs/user/protocol-definition.rst
+++ b/docs/user/protocol-definition.rst
@@ -56,10 +56,11 @@ Blocks
 Primitives
 ----------
 
+.. autofunction:: boofuzz.Static
+.. autofunction:: boofuzz.Simple
 .. autofunction:: boofuzz.Delim
 .. autofunction:: boofuzz.Group
 .. autofunction:: boofuzz.RandomData
-.. autofunction:: boofuzz.Static
 .. autofunction:: boofuzz.String
 .. autofunction:: boofuzz.FromFile
 .. autofunction:: boofuzz.Mirror

--- a/examples/ftp_simple.py
+++ b/examples/ftp_simple.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Designed for use with boofuzz v0.2.0
+"""Demo FTP fuzzer as a standalone script."""
 
 from boofuzz import *
 

--- a/examples/groups_demo.py
+++ b/examples/groups_demo.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Demo of Block and group functionality."""
+from boofuzz import *
+import boofuzz
+import click
+
+
+@click.command()
+@click.pass_context
+def groups_demo(ctx):
+    cli_context = ctx.obj
+    session = cli_context.session
+    session._receive_data_after_each_request = False
+
+    message1 = Request(
+        "message1",
+        children=(
+            Simple(name="first_byte", default_value=b"\x01", fuzz_values=[b"A", b"B", b"C"]),
+            Block(
+                name="first_block",
+                group=".first_byte",
+                children=(
+                    Simple(name="second_byte", default_value=b"\x02", fuzz_values=[b"1", b"2", b"3"]),
+                    # Simple(name="third_byte", default_value=b"\x03", fuzz_values=[b"X", b"Y", b"Z"]),
+                ),
+            ),
+        ),
+    )
+
+    session.connect(message1)
+
+
+if __name__ == "__main__":
+    boofuzz.main_helper(click_command=groups_demo)

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Demo of a very simple protocol definition using the Simple primitive."""
+from boofuzz import *
+import boofuzz
+import click
+
+
+@click.command()
+@click.pass_context
+def simple(ctx):
+    cli_context = ctx.obj
+    session = cli_context.session
+    session._receive_data_after_each_request = False
+
+    message1 = Request(
+        "message1",
+        children=(
+            Simple(name="first_byte", default_value=b"\x01", fuzz_values=[b"A", b"B", b"C"]),
+            Simple(name="second_byte", default_value=b"\x02", fuzz_values=[b"1", b"2", b"3"]),
+            Simple(name="third_byte", default_value=b"\x03", fuzz_values=[b"X", b"Y", b"Z"]),
+        ),
+    )
+
+    message2 = Request(
+        "message2",
+        children=(
+            Simple(name="first_byte", default_value=b"\x01", fuzz_values=[b"A", b"B", b"C"]),
+            Simple(name="second_byte", default_value=b"\x02", fuzz_values=[b"1", b"2", b"3"]),
+        ),
+    )
+
+    session.connect(message1)
+    session.connect(message1, message2)
+
+
+if __name__ == "__main__":
+    boofuzz.main_helper(click_command=simple)

--- a/unit_tests/test_blocks.py
+++ b/unit_tests/test_blocks.py
@@ -113,10 +113,10 @@ class TestBlocks(DebuggableTestCase):
         rendered = blocks.CURRENT.render()
         assert b"ONE" not in rendered
         assert b"TWO" not in rendered
-        rendered = blocks.CURRENT.render(MutationContext(mutation=mutations[0]))
+        rendered = blocks.CURRENT.render(MutationContext(mutations=mutations[0]))
         assert b"ONE" in rendered
         assert b"TWO" not in rendered
-        rendered = blocks.CURRENT.render(MutationContext(mutation=mutations[1]))
+        rendered = blocks.CURRENT.render(MutationContext(mutations=mutations[1]))
         assert b"ONE" not in rendered
         assert b"TWO" in rendered
         assert len(mutations) == 4
@@ -140,7 +140,7 @@ class TestBlocks(DebuggableTestCase):
 
         expected_lengths = [length + length * 5, length + length * 10, length + length * 15]
         for mutation, expected_length in zip(blocks.CURRENT.get_mutations(), expected_lengths):
-            data = blocks.CURRENT.render(MutationContext(mutation=mutation))
+            data = blocks.CURRENT.render(MutationContext(mutations=mutation))
             self.assertEqual(expected_length, len(data))
 
     def test_return_current_mutant(self):

--- a/unit_tests/test_fuzz_logger.py
+++ b/unit_tests/test_fuzz_logger.py
@@ -140,7 +140,7 @@ class TestFuzzLogger(unittest.TestCase):
         Then: failed_test_cases contains no failed test case info at first.
          and: failed_test_cases contains information from each log_fail,
               indexed by the opened test case, as each failure is added.
-         and: len(passed_test_cases) == 0
+         and: passed_test_case_count == 0
          and: len(error_test_cases) == 0
         """
         self.assertEqual(0, len(self.logger.failed_test_cases))
@@ -155,7 +155,7 @@ class TestFuzzLogger(unittest.TestCase):
         self.logger.log_fail("1110")
         self.assertEqual(["010", "11001", "1110"], self.logger.failed_test_cases["haiku"])
 
-        self.assertEqual(0, len(self.logger.passed_test_cases))
+        self.assertEqual(0, self.logger.passed_test_case_count)
         self.assertEqual(0, len(self.logger.error_test_cases))
 
     def test_error_count(self):
@@ -168,7 +168,7 @@ class TestFuzzLogger(unittest.TestCase):
         Then: error_test_cases contains no test error info at first.
          and: error_test_cases contains information from each log_error,
               indexed by the opened test case, as each error is added.
-         and: len(passed_test_cases) == 0
+         and: passed_test_case_count == 0
          and: len(failed_test_cases) == 0
         """
         self.assertEqual(0, len(self.logger.error_test_cases))
@@ -188,7 +188,7 @@ class TestFuzzLogger(unittest.TestCase):
         self.logger.log_error(line3)
         self.assertEqual([line1, line2, line3], self.logger.error_test_cases[5])
 
-        self.assertEqual(0, len(self.logger.passed_test_cases))
+        self.assertEqual(0, self.logger.passed_test_case_count)
         self.assertEqual(0, len(self.logger.failed_test_cases))
 
     def test_pass_count(self):
@@ -198,17 +198,16 @@ class TestFuzzLogger(unittest.TestCase):
          and: log_pass three times
          and: open_test_case
          and: log_pass once.
-        Then: passed_test_cases contains no test cases at first.
-         and: passed_test_cases contains information from each log_pass,
-              indexed by the opened test case, as each pass is added.
+        Then: passed_test_case_count == 0 at first.
+         and: passed_test_case_count == 1, then 2, as each pass is added.
          and: len(failed_test_cases) == 0
          and: len(error_test_cases) == 0
         """
-        self.assertEqual(0, len(self.logger.passed_test_cases))
+        self.assertEqual(0, self.logger.passed_test_case_count)
 
         self.logger.open_test_case(test_case_id="a", name=self.some_other_text, index=self.some_int)
         self.logger.log_pass("Good to go")
-        self.assertEqual(["Good to go"], self.logger.passed_test_cases["a"])
+        self.assertEqual(1, self.logger.passed_test_case_count)
 
         self.logger.open_test_case(test_case_id=-1, name=self.some_other_text, index=self.some_int)
 
@@ -218,7 +217,7 @@ class TestFuzzLogger(unittest.TestCase):
         self.logger.log_pass(line1)
         self.logger.log_pass(line2)
         self.logger.log_pass(line3)
-        self.assertEqual([line1, line2, line3], self.logger.passed_test_cases[-1])
+        self.assertEqual(2, self.logger.passed_test_case_count)
 
         self.assertEqual(0, len(self.logger.failed_test_cases))
         self.assertEqual(0, len(self.logger.error_test_cases))
@@ -233,25 +232,25 @@ class TestFuzzLogger(unittest.TestCase):
          and: log_fail
          and: open_test_case
          and: log_error
-        Then: all_test_cases contains no test cases at first.
-         and: all_test_cases contains each opened test case, as each is added.
+        Then: test_case_count contains no test cases at first.
+         and: test_case_count contains each opened test case, as each is added.
         """
-        self.assertEqual([], self.logger.all_test_cases)
+        self.assertEqual(0, self.logger.test_case_count)
 
         self.logger.open_test_case(test_case_id="a", name=self.some_other_text, index=self.some_int)
-        self.assertEqual(["a"], self.logger.all_test_cases)
+        self.assertEqual(1, self.logger.test_case_count)
 
         self.logger.open_test_case(test_case_id="b", name=self.some_other_text, index=self.some_int)
         self.logger.log_pass()
-        self.assertEqual(["a", "b"], self.logger.all_test_cases)
+        self.assertEqual(2, self.logger.test_case_count)
 
         self.logger.open_test_case(test_case_id="c", name=self.some_other_text, index=self.some_int)
         self.logger.log_fail()
-        self.assertEqual(["a", "b", "c"], self.logger.all_test_cases)
+        self.assertEqual(3, self.logger.test_case_count)
 
         self.logger.open_test_case(test_case_id="d", name=self.some_other_text, index=self.some_int)
         self.logger.log_error(description="uh oh!")
-        self.assertEqual(["a", "b", "c", "d"], self.logger.all_test_cases)
+        self.assertEqual(4, self.logger.test_case_count)
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_s_checksum.py
+++ b/unit_tests/test_s_checksum.py
@@ -30,4 +30,4 @@ def scenario_output_is(context, value):
 def scenario_can_render_all_mutations(context):
     mutations = list(context.req.get_mutations())
     for mutation in mutations:
-        context.req.render(MutationContext(mutation=mutation))
+        context.req.render(MutationContext(mutations=mutation))

--- a/unit_tests/test_s_group.py
+++ b/unit_tests/test_s_group.py
@@ -55,13 +55,13 @@ def scenario_output_as(context, mutation, result):
         result = result[2:]
         result = bytes(bytearray.fromhex(result))
     mutation = int(mutation)
-    assert context.req.render(MutationContext(mutation=context.mutations[mutation])) == result
+    assert context.req.render(MutationContext(mutations=context.mutations[mutation])) == result
 
 
 @then("All mutations render")
 def scenario_can_render_all_mutations(context):
     for mutation in context.mutations:
-        context.req.render(MutationContext(mutation=mutation))
+        context.req.render(MutationContext(mutations=mutation))
 
 
 @then(parsers.parse("There are {value:d} total mutations"))

--- a/unit_tests/test_s_repeat.py
+++ b/unit_tests/test_s_repeat.py
@@ -30,4 +30,4 @@ def scenario_output_is(context, value):
 def scenario_can_render_all_mutations(context):
     mutations = list(context.req.get_mutations())
     for mutation in mutations:
-        context.req.render(MutationContext(mutation=mutation))
+        context.req.render(MutationContext(mutations=mutation))


### PR DESCRIPTION
…(#499)

* add main_helper() for easy CLIs

* Fixing style errors.

* minor cleanup

* Fixing style errors.

* Session._protocol_mutations()

* combinatorial mutations working! for basic case at least

- add Simple primitive which fuzzes with only specific values
- Mutation object now contains a index
- MutationContext now contains mutations, a dict of Mutation objects
    - Simplifies MutaitonContext constructor, removes unintuitive mutation_context.mutation.mutations construct
- MutationContext now contains message_path, reflecting the truth that right now groups of mutations are only tracked within a single request

* cleanup on combinatiorial fuzzing; still need to remove duplicates

* combinations instead of product to remove sort duplicates

* --target instead of --target-host and --target-port

* Fixing style errors.

* CHANGELOG

* fuzz single test case with multiple mutations by name

* WIP refactoring generation code

* rename mutation methods

* rearranging mutation methods and fix --test-case-index param...

Session.fuzz_single_case() now gives a deprecation warning.

* fix blank UI screen when using --test-case-index

* deprecate warning for fuzz_by_name

* update Session internal method docstrings

* fix runaway recursion slowdown

* fix memory leaks

* add run time and exec speed to stats

* add --keep-web and --record_pre_failure_test_cases

* minor web UI fixes

* fix --feature-check

* stop runtime timer when fuzzing is done

* unit test fixes

* unit tests passing

* documentation and examples

* Fixing style errors.

* fix simple.py example

* rename arg --record-passes

* stickler fixes

* review fixes

* Fixing style errors.

* add "current" to Web UI showing current test case name

Co-authored-by: stickler-ci <support@stickler-ci.com>